### PR TITLE
[BUGFIX] split c_step and orderid / code in realurl configuration

### DIFF
--- a/Classes/Custom/Realurl.php
+++ b/Classes/Custom/Realurl.php
@@ -95,6 +95,8 @@ class Realurl
 					),
 					'co' => array(
 						array( 'GETvar' => 'ai[c_step]' ),
+					),
+					'cc' => array(
 						array( 'GETvar' => 'code' ),
 						array( 'GETvar' => 'orderid' ),
 					),


### PR DESCRIPTION
ai[c_step] is not always set during the checkout,
so therefore it needs to be split from orderid and code