### PR TITLE
Bug fix for bootstrap_package 7 with realurl

### DIFF
--- a/Classes/Custom/Realurl.php
+++ b/Classes/Custom/Realurl.php
@@ -3,7 +3,7 @@
 /**
  * @license GPLv3, http://www.gnu.org/copyleft/gpl.html
  * @copyright Metaways Infosystems GmbH, 2013
- * @copyright Aimeos (aimeos.org), 2014-2016
+ * @copyright Aimeos (aimeos.org), 2014-2017
  * @package TYPO3
  */
 
@@ -30,8 +30,34 @@ class Realurl
 		$params['config']['init']['emptySegmentValue'] = '';
 
 		return array_merge_recursive( $params['config'], array(
+			/* start: missing at bootstrap_package 7, can be removed if reincluded there */
+			'preVars' => array(
+				'0' => array(
+					'GETvar' => 'no_cache',
+					'valueMap' => array(
+						'nc' => '1',
+					),
+					'noMatch' => 'bypass'
+				),
+				'1' => array(
+					'GETvar' => 'L',
+					'valueMap' => array(
+						'de' => '1',
+						'da' => '2',
+					),
+					'noMatch' => 'bypass',
+				)
+			),
+			/* end */
 			'postVarSets' => array(
 				'_DEFAULT' => array(
+					/* start: missing at bootstrap_package 7, can be removed if reincluded there */
+					'page' => array(
+						0 => array(
+							'GETvar' => 'page',
+						)
+					),
+					/* end */
 					'aimeos' => array(
 						array(
 							'GETvar' => 'ai[controller]',

--- a/Classes/Custom/Realurl.php
+++ b/Classes/Custom/Realurl.php
@@ -11,6 +11,9 @@
 namespace Aimeos\Aimeos\Custom;
 
 
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+
+
 /**
  * Aimeos RealURL configuraiton.
  *
@@ -29,7 +32,7 @@ class Realurl
 	{
 		$params['config']['init']['emptySegmentValue'] = '';
 
-		$this->addNoCache( $params['config'] );
+		$this->addNoCache( $params );
 
 		return array_merge_recursive( $params['config'], array(
 			'postVarSets' => array(
@@ -126,11 +129,12 @@ class Realurl
 	 * @return void
 	 */
 	protected function addNoCache(array &$configuration) {
-		if ( array_search( 'no_cache', $configuration ) !== false ) {
+		$nocache = ArrayUtility::filterByValueRecursive( 'no_cache', $configuration );
+		if ( isset( $nocache ) && !empty( $nocache ) ) {
 			return;
 		}
 
-		$configuration['preVars'][] = array(
+		$configuration['config']['preVars'][] = array(
 			'GETvar' => 'no_cache',
 			'valueMap' => array(
 				'nc' => '1',

--- a/Classes/Custom/Realurl.php
+++ b/Classes/Custom/Realurl.php
@@ -30,34 +30,17 @@ class Realurl
 		$params['config']['init']['emptySegmentValue'] = '';
 
 		return array_merge_recursive( $params['config'], array(
-			/* start: missing at bootstrap_package 7, can be removed if reincluded there */
 			'preVars' => array(
-				'0' => array(
+				array(
 					'GETvar' => 'no_cache',
 					'valueMap' => array(
 						'nc' => '1',
 					),
 					'noMatch' => 'bypass'
 				),
-				'1' => array(
-					'GETvar' => 'L',
-					'valueMap' => array(
-						'de' => '1',
-						'da' => '2',
-					),
-					'noMatch' => 'bypass',
-				)
 			),
-			/* end */
 			'postVarSets' => array(
 				'_DEFAULT' => array(
-					/* start: missing at bootstrap_package 7, can be removed if reincluded there */
-					'page' => array(
-						0 => array(
-							'GETvar' => 'page',
-						)
-					),
-					/* end */
 					'aimeos' => array(
 						array(
 							'GETvar' => 'ai[controller]',

--- a/Classes/Custom/Realurl.php
+++ b/Classes/Custom/Realurl.php
@@ -32,15 +32,6 @@ class Realurl
 		$this->addNoCache( $params['config'] );
 
 		return array_merge_recursive( $params['config'], array(
-			'preVars' => array(
-				array(
-					'GETvar' => 'no_cache',
-					'valueMap' => array(
-						'nc' => '1',
-					),
-					'noMatch' => 'bypass'
-				),
-			),
 			'postVarSets' => array(
 				'_DEFAULT' => array(
 					'aimeos' => array(

--- a/Classes/Custom/Realurl.php
+++ b/Classes/Custom/Realurl.php
@@ -29,6 +29,8 @@ class Realurl
 	{
 		$params['config']['init']['emptySegmentValue'] = '';
 
+		$this->addNoCache( $params['config'] );
+
 		return array_merge_recursive( $params['config'], array(
 			'preVars' => array(
 				array(
@@ -124,5 +126,25 @@ class Realurl
 				),
 			),
 		) );
+	}
+
+	/**
+	 * Adds no_cache to configuration if not already defined
+	 *
+	 * @param array $configuration
+	 * @return void
+	 */
+	protected function addNoCache(array &$configuration) {
+		if ( array_search( 'no_cache', $configuration ) !== false ) {
+			return;
+		}
+
+		$configuration['preVars'][] = array(
+			'GETvar' => 'no_cache',
+			'valueMap' => array(
+				'nc' => '1',
+			),
+			'noMatch' => 'bypass',
+		);
 	}
 }


### PR DESCRIPTION
In bootstrap_package 7 realurl autoconfig is missing and no_cache (/nc/ in URI) not longer works. Today my realurl autoconfig was rewritten and all targets with the no cache option were not longer reachable. Functions like the search I tested the last days not longer worked. Here the change log entry of bootstrap_package 7:

- [TASK] Remove realurl autoconfiguration in preparation for realurl 2 b44a798

Here the minimal changes to get it running again.