### PR TITLE
Changed language and currency parameter names to defaults TYPO3 locale

### DIFF
--- a/Resources/Private/Config/client.php
+++ b/Resources/Private/Config/client.php
@@ -1,0 +1,22 @@
+<?php
+
+return array(
+	'html' => array(
+		'locale' => array(
+			'select' => array(
+
+				// Language related settings
+				'language' => array(
+					// Name of the parameter that contains the language ID value
+					'param-name' => 'loc_language',
+				),
+
+				// Currency related settings
+				'currency' => array(
+					// Name of the parameter that contains the currency ID value
+					'param-name' => 'loc_currency',
+				),
+			),
+		),
+	),
+);

--- a/Resources/Private/Config/client.php
+++ b/Resources/Private/Config/client.php
@@ -8,13 +8,13 @@ return array(
 				// Language related settings
 				'language' => array(
 					// Name of the parameter that contains the language ID value
-					'param-name' => 'loc_language',
+					'param-name' => 'locale',
 				),
 
 				// Currency related settings
 				'currency' => array(
 					// Name of the parameter that contains the currency ID value
-					'param-name' => 'loc_currency',
+					'param-name' => 'currency',
 				),
 			),
 		),


### PR DESCRIPTION
Language / currency selector does not run because different names in locale.php. So I created a new default config for TYPO3 to not touch other distros