### PR TITLE
Boostrap 7 fixes

### DIFF
--- a/Classes/Custom/ExtensionCondition.php
+++ b/Classes/Custom/ExtensionCondition.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @license GPLv3, http://www.gnu.org/copyleft/gpl.html
+ * @copyright Gilbertsoft (gilbertsoft.org), 2017
+ * @copyright Aimeos (aimeos.org), 2017
+ * @package TYPO3
+ */
+
+
+namespace Aimeos\Aimeos\Custom;
+
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+
+
+/**
+ * This TypoScript condition checks whether a extension is installed or not including version compares
+ *
+ * = Example =
+ * [userFunc = \Aimeos\Aimeos\Custom\ExtensionCondition::match(bootstrap_package, greaterOrEqualThan, 7.0.0)]
+ *   page.6 = TEXT
+ *   page.6.value = LOWER CMS 7
+ *   page.6.wrap = <div>|</div>
+ * [global]
+ *
+ */
+class ExtensionCondition
+{
+
+	/**
+	 * @param string $extension
+	 * @param string $operator
+	 * @param integer $value
+	 * @return bool
+	 */
+	public function match($extension, $operator = null, $value = null)
+	{
+		$version = ExtensionManagementUtility::getExtensionVersion( $extension );
+		$result = !empty( $version );
+
+		if( !empty( $operator ) ) {
+			if( !$result && $operator === "notInstalled" ) {
+				$result =  true;
+			} elseif( $result && !empty( $value ) ) {
+				$result = false;
+				$version = VersionNumberUtility::convertVersionNumberToInteger( $version );
+				$value = VersionNumberUtility::convertVersionNumberToInteger( $value );
+
+				//ExtensionManagementUtility::isLoaded( );
+				if ($operator === "equals" && $version === $value) {
+					$result = true;
+				} elseif ($operator === "lessThan" && $version < $value) {
+					$result = true;
+				} elseif ($operator === "lessOrEqualThan" && $version <= $value) {
+					$result = true;
+				} elseif ($operator === "greaterThan" && $version > $value) {
+					$result = true;
+				} elseif ($operator === "greaterOrEqualThan" && $version >= $value) {
+					$result = true;
+				}
+			} else {
+				$result = false;
+			}
+		}
+
+		return $result;
+	}
+}

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -3,8 +3,10 @@ page.includeCSS.aimeos = {$plugin.tx_aimeos.theme.css.aimeos}
 page.includeCSS.aimeos-theme-common = {$plugin.tx_aimeos.theme.css.custom-common}
 page.includeCSS.aimeos-theme = {$plugin.tx_aimeos.theme.css.custom}
 
+[userFunc = \Aimeos\Aimeos\Custom\ExtensionCondition::match(bootstrap_package, notInstalled)]
 page.includeJSFooterlibs.jquery = https://code.jquery.com/jquery-3.1.1.min.js
 page.includeJSFooterlibs.jquery.external = 1
+[global]
 page.includeJSFooterlibs.jquery-ui = EXT:aimeos/Resources/Public/Themes/jquery-ui.custom.min.js
 
 page.includeJSFooter.aimeos = {$plugin.tx_aimeos.theme.js.aimeos}


### PR DESCRIPTION
There are still problems with boostrap 7. e.g. fails completly on mobile devices if jQuery higher than 2 is included. Generally there are multiple warnings on the console that versions higher than 2 are not supported. I wrote a custom condition for TypoScript to enable various checks on installed extensions and versions and added a condition for the including of jQuery.