### PR TITLE
Fix scheduler content object injection

### DIFF
--- a/Classes/Scheduler/Base.php
+++ b/Classes/Scheduler/Base.php
@@ -112,6 +112,7 @@ class Base
 			$uriBuilder->injectConfigurationManager( $configurationManager );
 		}
 
+		$uriBuilder->initializeObject();
 		$uriBuilder->setArgumentPrefix( 'ai' );
 
 		return $uriBuilder;


### PR DESCRIPTION
UriBuilder->initializeObject() needs to be called to extract the content object from the inejcted configuration manager. Otherwise, a null pointer exception is thrown when calling the scheduler via cli_dispatch and trying to access the content object. See #51 