### PR TITLE
Make Typo3 page tree visibility configurable

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -12,3 +12,5 @@ cacheName = Typo3
 useAPC = 0
 # cat=cache/apc; type=string; label=APC prefix:The prefix to distinguish configuration values from different instances
 apcPrefix = t3:
+# cat=backend; type=boolean; label=Show Typo3 page tree in backend
+showPageTree = 1

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -20,8 +20,21 @@ $TBE_MODULES_EXT['xMOD_db_new_content_el']['addElClasses']['Aimeos\\Aimeos\\Cust
 if ( TYPO3_MODE === 'BE' )
 {
 	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
+	        'Aimeos.' . $_EXTKEY,
+	        'Aimeos',
+	        '',
+	        '',
+	        [],
+	        [
+	            'icon' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/Extension.svg',
+	            'access' => 'user,group',
+	            'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/admin.xlf',
+	        ]
+    	);
+
+	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
 		'Aimeos.' . $_EXTKEY,
-		'web',
+		'Aimeos',
 		'tx_aimeos_admin',
 		'', // position
 		array(

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -19,19 +19,6 @@ $TBE_MODULES_EXT['xMOD_db_new_content_el']['addElClasses']['Aimeos\\Aimeos\\Cust
 
 if ( TYPO3_MODE === 'BE' )
 {
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-        'Aimeos.' . $_EXTKEY,
-        'Aimeos',
-        '',
-        '',
-        [],
-        [
-            'icon' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/Extension.svg',
-            'access' => 'user,group',
-            'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/admin.xlf',
-        ]
-    );
-    
     $_moduleConfiguration = array(
         'access' => 'user,group',
         'icon' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/Extension.svg',
@@ -39,14 +26,16 @@ if ( TYPO3_MODE === 'BE' )
     );
     if ( ! (bool)\Aimeos\Aimeos\Base::getExtConfig('showPageTree', true)) {
         $_moduleConfiguration['navigationComponentId'] = null;
+        $_moduleConfiguration['inheritNavigationComponentFromMainModule'] = false;
     }
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
 		'Aimeos.' . $_EXTKEY,
-		'Aimeos',
+		'web',
 		'tx_aimeos_admin',
 		'', // position
 		array(
+			'Admin' => 'index',
 			'Jqadm' => 'search,copy,create,delete,get,save,file',
 			'Extadm' => 'index,do,file',
 			'Jsonadm' => 'index',

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -19,35 +19,39 @@ $TBE_MODULES_EXT['xMOD_db_new_content_el']['addElClasses']['Aimeos\\Aimeos\\Cust
 
 if ( TYPO3_MODE === 'BE' )
 {
-	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-	        'Aimeos.' . $_EXTKEY,
-	        'Aimeos',
-	        '',
-	        '',
-	        [],
-	        [
-	            'icon' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/Extension.svg',
-	            'access' => 'user,group',
-	            'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/admin.xlf',
-	        ]
-    	);
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
+        'Aimeos.' . $_EXTKEY,
+        'Aimeos',
+        '',
+        '',
+        [],
+        [
+            'icon' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/Extension.svg',
+            'access' => 'user,group',
+            'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/admin.xlf',
+        ]
+    );
+    
+    $_moduleConfiguration = array(
+        'access' => 'user,group',
+        'icon' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/Extension.svg',
+        'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/admin.xlf',
+    );
+    if ( ! (bool)\Aimeos\Aimeos\Base::getExtConfig('showPageTree', true)) {
+        $_moduleConfiguration['navigationComponentId'] = null;
+    }
 
-	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
 		'Aimeos.' . $_EXTKEY,
 		'Aimeos',
 		'tx_aimeos_admin',
 		'', // position
 		array(
-			'Admin' => 'index',
 			'Jqadm' => 'search,copy,create,delete,get,save,file',
 			'Extadm' => 'index,do,file',
 			'Jsonadm' => 'index',
 		),
-		array(
-			'access' => 'user,group',
-			'icon' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/Extension.svg',
-			'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/admin.xlf',
-		)
+		$_moduleConfiguration
 	);
 }
 


### PR DESCRIPTION
All modules under "web" will show the directory panel in Typo3.
As this just uses up space and has no meaning to aimeos, there are 2 options:

1. Put the aimeos module in the existing main modules 'system', 'user' or 'tools'
2. Insert new "Aimeos" main module

I went for the second option as neither of the existing categories really fits and I wanted Aimeos to "stand out" from the other modules. From Typo3 v7+ on the main module will also show an icon which adds clarity for the editor.
