### PR TITLE
Fix symlink creation in composer installer

### DIFF
--- a/Classes/Custom/Composer.php
+++ b/Classes/Custom/Composer.php
@@ -116,21 +116,14 @@ class Composer
 	 */
 	protected static function createLink( $source, $target )
 	{
-		if (file_exists($target) === false) {
-			try {
-				if (symlink($source, $target) === true) {
-					return;
-				}
-			} catch (\ErrorException $e) {
-			}
+		if( file_exists( $target ) === false && @symlink( $source, $target ) === false )
+		{
+			$source = realpath( __DIR__ . '/' . $source );
 
-			$source = realpath(__DIR__ . '/' . $source);
-			if (symlink($source, $target) === true) {
-				return;
+			if( symlink( $source, $target ) === false ) {
+				throw new \RuntimeException( sprintf( 'Failed to create symlink for "%1$s" to "%2$s"', $source, $target ) );
 			}
 		}
-
-		throw new \RuntimeException(sprintf('Failed to create symlink for "%1$s" to "%2$s"', $source, $target));
 	}
 
 

--- a/Classes/Custom/Composer.php
+++ b/Classes/Custom/Composer.php
@@ -116,14 +116,21 @@ class Composer
 	 */
 	protected static function createLink( $source, $target )
 	{
-		if( file_exists( $target ) === false && symlink( $source, $target ) === false )
-		{
-			$source = realpath( __DIR__ . '/' . $source );
+		if (file_exists($target) === false) {
+			try {
+				if (symlink($source, $target) === true) {
+					return;
+				}
+			} catch (\ErrorException $e) {
+			}
 
-			if( symlink( $source, $target ) === false ) {
-				throw new \RuntimeException( sprintf( 'Failed to create symlink for "%1$s" to "%2$s"', $source, $target ) );
+			$source = realpath(__DIR__ . '/' . $source);
+			if (symlink($source, $target) === true) {
+				return;
 			}
 		}
+
+		throw new \RuntimeException(sprintf('Failed to create symlink for "%1$s" to "%2$s"', $source, $target));
 	}
 
 


### PR DESCRIPTION
This patch ensures the realpath fallback is used, if symlink()
fails for the first time. On Windows systems symlink() throws an
ErrorException if the source cannot be verified.

Fixes: #65 