### PR TITLE
MySql compartibility check during the update script

### DIFF
--- a/Resources/Private/Language/admin.xlf
+++ b/Resources/Private/Language/admin.xlf
@@ -19,7 +19,7 @@
 				<source>The database connection '%s' has a wrong configuration. To use the Aimeos Shop, you will need to adjust it.</source>
 			</trans-unit>
 			<trans-unit id="t3_9x_config_error_remedy" xml:space="preserve">
-				<source><![CDATA[<p>Please follow the steps described here:<p><a target="_blank" href="https://github.com/aimeos/aimeos-typo3#database-setup">https://github.com/aimeos/aimeos-typo3#database-setup</a></p></p>]]></source>
+				<source><![CDATA[<p>Please follow the steps described here:</p><p><a target="_blank" href="https://github.com/aimeos/aimeos-typo3#database-setup">https://github.com/aimeos/aimeos-typo3#database-setup</a></p>]]></source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/admin.xlf
+++ b/Resources/Private/Language/admin.xlf
@@ -12,6 +12,12 @@
 			<trans-unit id="mlang_labels_tabdescr" xml:space="preserve">
 				<source>Administration Aimeos Shop</source>
 			</trans-unit>
+			<trans-unit id="t3_9x_config_error_header" xml:space="preserve">
+				<source>Wrong configuration detected</source>
+			</trans-unit>
+			<trans-unit id="t3_9x_config_error_text" xml:space="preserve">
+				<source>The database connection '%s' has a wrong configuration! Please fix!  :-)</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/admin.xlf
+++ b/Resources/Private/Language/admin.xlf
@@ -16,7 +16,10 @@
 				<source>Wrong configuration detected</source>
 			</trans-unit>
 			<trans-unit id="t3_9x_config_error_text" xml:space="preserve">
-				<source>The database connection '%s' has a wrong configuration! Please fix!  :-)</source>
+				<source>The database connection '%s' has a wrong configuration. To use the Aimeos Shop, you will need to adjust it.</source>
+			</trans-unit>
+			<trans-unit id="t3_9x_config_error_remedy" xml:space="preserve">
+				<source>Please follow the steps described here:</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/admin.xlf
+++ b/Resources/Private/Language/admin.xlf
@@ -19,7 +19,7 @@
 				<source>The database connection '%s' has a wrong configuration. To use the Aimeos Shop, you will need to adjust it.</source>
 			</trans-unit>
 			<trans-unit id="t3_9x_config_error_remedy" xml:space="preserve">
-				<source>Please follow the steps described here:</source>
+				<source><![CDATA[<p>Please follow the steps described here:<p><a target="_blank" href="https://github.com/aimeos/aimeos-typo3#database-setup">https://github.com/aimeos/aimeos-typo3#database-setup</a></p></p>]]></source>
 			</trans-unit>
 		</body>
 	</file>

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -89,21 +89,21 @@ class ext_update
 	 */
 	protected function checkEnvironment(): bool
 	{
-		if (version_compare(TYPO3_version, '9.5', '<')) {
+		if ( version_compare( TYPO3_version, '9.5', '<' ) ) {
 			// Wrong TYPO3 version.
 			return true;
 		}
 
 		/** @var ObjectManager $objectManager */
-		$objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+		$objectManager = GeneralUtility::makeInstance( ObjectManager::class );
 
 		/** @var ConnectionPool $connectionPool */
-		$connectionPool = $objectManager->get(ConnectionPool::class);
+		$connectionPool = $objectManager->get( ConnectionPool::class );
 		// A join with tables from different databases will throw an exception.
 		// Hence, it is extreme likely that aimeos will be installed on the same
 		// database.
 		$connection = $connectionPool
-			->getQueryBuilderForTable('fe_user')
+			->getQueryBuilderForTable( 'fe_user' )
 			->getConnection();
 
 		// Test the server type
@@ -116,17 +116,24 @@ class ext_update
 		}
 
 		// Test the parameters
+        // When the parameters are not set, the sql will fail.
 		$params = $connection->getParams();
-		if ($params['tableoptions']['charset'] === 'utf8' ||
+		if ( isset( $params['tableoptions']['charset'] ) &&
+		    $params['tableoptions']['charset'] === 'utf8' &&
+            isset( $params['tableoptions']['collate'] ) &&
 			$params['tableoptions']['collate'] === 'utf8_bin'
 		) {
+		    // @todo running the setup script a second time quits with an error
+            //        The script tries to  run a
+            //        ALTER TABLE "mshop_customer" CONVERT TO CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin'
+            //        which fails with s 5.6 MySql version.
 			return true;
 		}
 
 		// Retrieve the name of the connection (which is not part of the
 		// connection class)
 		foreach ( $connectionPool->getConnectionNames() as $name ) {
-			if ($connectionPool->getConnectionByName($name) === $connection) {
+			if ( $connectionPool->getConnectionByName( $name ) === $connection ) {
 				break;
 			}
 		}

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -119,7 +119,7 @@ class ext_update
 		// Test the parameters
 		// When the parameters are not set, the sql will fail.
 		$params = $connection->getParams();
-		if ( isset( $params['tableoptions']['collate'] ) && $params['tableoptions']['collate'] === 'utf8_bin' )
+		if( isset( $params['tableoptions']['charset'] ) && $params['tableoptions']['charset'] === 'utf8' )
 		{
 			return;
 		}

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -89,7 +89,7 @@ class ext_update
 	 */
 	protected function checkEnvironment(): bool
 	{
-		if ( version_compare( TYPO3_version, '9.5', '<' ) )
+		if ( version_compare( TYPO3_version, '9.0', '<' ) )
 		{
 			// Wrong TYPO3 version.
 			return true;

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -155,12 +155,8 @@ class ext_update
 
 		$this->message = $objectManager->get( FlashMessageRendererResolver::class )
 			->resolve()
-			->render( $flashMessages );
-
-		$url = 'https://github.com/aimeos/aimeos-typo3#database-setup';
-
-		$this->message .= '<p>' . LocalizationUtility::translate( 'LLL:EXT:aimeos/Resources/Private/Language/admin.xlf:t3_9x_config_error_remedy' ) . '</p>';
-		$this->message .= '<p><a href="' . $url . '">' . $url . '</a></p>';
+			->render( $flashMessages ) .
+			LocalizationUtility::translate( 'LLL:EXT:aimeos/Resources/Private/Language/admin.xlf:t3_9x_config_error_remedy' );
 
 		return false;
 	}

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -120,11 +120,8 @@ class ext_update
 		// Test the parameters
 		// When the parameters are not set, the sql will fail.
 		$params = $connection->getParams();
-		if ( isset( $params['tableoptions']['charset'] ) &&
-			$params['tableoptions']['charset'] === 'utf8' &&
-			isset( $params['tableoptions']['collate'] ) &&
-			$params['tableoptions']['collate'] === 'utf8_bin'
-		) {
+		if ( isset( $params['tableoptions']['collate'] ) && $params['tableoptions']['collate'] === 'utf8_bin' )
+		{
 			return;
 		}
 

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -127,7 +127,7 @@ class ext_update
 		// Retrieve the name of the connection (which is not part of the
 		// connection class)
 		foreach ( $connectionPool->getConnectionNames() as $name ) {
-			if ( $connectionPool->getConnectionByName( $name ) === $connection ) {
+			if( $connectionPool->getConnectionByName( $name ) === $connection ) {
 				break;
 			}
 		}

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -152,6 +152,11 @@ class ext_update
 			->resolve()
 			->render( $flashMessages );
 
+		$url = 'https://github.com/aimeos/aimeos-typo3#database-setup';
+
+		$this->message .= '<p>' . LocalizationUtility::translate( 'LLL:EXT:aimeos/Resources/Private/Language/admin.xlf:t3_9x_config_error_remedy' ) . '</p>';
+		$this->message .= '<p><a href="' . $url . '">' . $url . '</a></p>';
+
 		return false;
 	}
 }

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -47,8 +47,7 @@ class ext_update
 		ob_start();
 		$exectimeStart = microtime( true );
 
-		$result = $this->checkEnvironment();
-		if ( $result ) {
+		if( ( $result = $this->checkEnvironment() ) !== null ) {
 			return $result;
 		}
 

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -29,7 +29,7 @@ if( file_exists( $localautoloader ) === true ) {
 class ext_update
 {
 	/**
-	 * Array with possible flash messages.
+	 * The rendered feedback message in case of a compatibility problem
 	 *
 	 * @var string
 	 */

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -102,7 +102,7 @@ class ext_update
 		$connectionPool = $objectManager->get( ConnectionPool::class );
 		// A join with tables from different databases will throw an exception.
 		// Hence, it is extreme likely that aimeos will be installed on the same
-		// database.
+		// database where the fe_user is located.
 		$connection = $connectionPool
 			->getQueryBuilderForTable( 'fe_user' )
 			->getConnection();
@@ -124,11 +124,6 @@ class ext_update
 			isset( $params['tableoptions']['collate'] ) &&
 			$params['tableoptions']['collate'] === 'utf8_bin'
 		) {
-			// @todo running the setup script a second time quits with an error
-			// The script tries to  run a
-			// ALTER TABLE "mshop_customer" CONVERT TO CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin'
-			// which fails with s 5.6 MySql version.
-			// @see \Aimeos\MW\Setup\Task\TablesUpdateCharsetCollation::checkTables
 			return true;
 		}
 

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -116,14 +116,10 @@ class ext_update
 			// Something like '10.1.29-MariaDB' or '5.6.33-0ubuntu0...'
 			$version = $result->fetchAll()[0]['version()'];
 
-			if( strpos( $version, 'MariaDB' ) !== false &&
-				version_compare( $version, '10.2', '>=' )
+			if( ( strpos( $version, 'MariaDB' ) !== false
+				&& version_compare( $version, '10.2', '>=' ) )
+				|| version_compare( $version, '5.7', '>=' )
 			) {
-				return true;
-			}
-
-			if( version_compare( $version, '5.7', '>=' ) )
-			{
 				return true;
 			}
 		}

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -117,18 +117,18 @@ class ext_update
 		}
 
 		// Test the parameters
-        // When the parameters are not set, the sql will fail.
+		// When the parameters are not set, the sql will fail.
 		$params = $connection->getParams();
 		if ( isset( $params['tableoptions']['charset'] ) &&
-		    $params['tableoptions']['charset'] === 'utf8' &&
-            isset( $params['tableoptions']['collate'] ) &&
+			$params['tableoptions']['charset'] === 'utf8' &&
+			isset( $params['tableoptions']['collate'] ) &&
 			$params['tableoptions']['collate'] === 'utf8_bin'
 		) {
-		    // @todo running the setup script a second time quits with an error
-            // The script tries to  run a
-            // ALTER TABLE "mshop_customer" CONVERT TO CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin'
-            // which fails with s 5.6 MySql version.
-            // @see \Aimeos\MW\Setup\Task\TablesUpdateCharsetCollation::checkTables
+			// @todo running the setup script a second time quits with an error
+			// The script tries to  run a
+			// ALTER TABLE "mshop_customer" CONVERT TO CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin'
+			// which fails with s 5.6 MySql version.
+			// @see \Aimeos\MW\Setup\Task\TablesUpdateCharsetCollation::checkTables
 			return true;
 		}
 

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -89,7 +89,8 @@ class ext_update
 	 */
 	protected function checkEnvironment(): bool
 	{
-		if ( version_compare( TYPO3_version, '9.5', '<' ) ) {
+		if ( version_compare( TYPO3_version, '9.5', '<' ) )
+		{
 			// Wrong TYPO3 version.
 			return true;
 		}
@@ -108,7 +109,7 @@ class ext_update
 
 		// Test the server type
 		// @todo test MariaDB
-		//	   According to the releases, the next version here would be 10.0
+		// According to the releases, the next version here would be 10.0
 		if ( strpos( $connection->getServerVersion(), 'MySQL' ) === 0 &&
 			version_compare( $connection->getWrappedConnection()->getServerVersion(), '5.7', '>=' )
 		) {
@@ -124,9 +125,10 @@ class ext_update
 			$params['tableoptions']['collate'] === 'utf8_bin'
 		) {
 		    // @todo running the setup script a second time quits with an error
-            //        The script tries to  run a
-            //        ALTER TABLE "mshop_customer" CONVERT TO CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin'
-            //        which fails with s 5.6 MySql version.
+            // The script tries to  run a
+            // ALTER TABLE "mshop_customer" CONVERT TO CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin'
+            // which fails with s 5.6 MySql version.
+            // @see \Aimeos\MW\Setup\Task\TablesUpdateCharsetCollation::checkTables
 			return true;
 		}
 

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -86,7 +86,7 @@ class ext_update
 	 *
 	 * @return bool
 	 */
-	protected function checkEnvironment(): bool
+	protected function checkEnvironment()
 	{
 		if( version_compare( TYPO3_version, '9.0', '<' ) )
 		{
@@ -115,13 +115,13 @@ class ext_update
 			$result->execute();
 			// Something like '10.1.29-MariaDB' or '5.6.33-0ubuntu0...'
 			$version = $result->fetchAll()[0]['version()'];
-			
+
 			if( strpos( $version, 'MariaDB' ) !== false &&
 				version_compare( $version, '10.2', '>=' )
 			) {
 				return true;
 			}
-			
+
 			if( version_compare( $version, '5.7', '>=' ) )
 			{
 				return true;

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -28,13 +28,6 @@ if( file_exists( $localautoloader ) === true ) {
 class ext_update
 {
 	/**
-	 * The rendered feedback message in case of a compatibility problem
-	 *
-	 * @var string
-	 */
-	protected $message = '';
-
-	/**
 	 * Returns the status if an update is necessary.
 	 *
 	 * @return boolean True if the update entry is available, false if not
@@ -43,7 +36,6 @@ class ext_update
 	{
 		return true;
 	}
-
 
 	/**
 	 * Main update method called by the extension manager.
@@ -55,8 +47,9 @@ class ext_update
 		ob_start();
 		$exectimeStart = microtime( true );
 
-		if ( $this->checkEnvironment() === false ) {
-			return $this->message;
+		$result = $this->checkEnvironment();
+		if ( $result ) {
+			return $result;
 		}
 
 		try
@@ -83,14 +76,15 @@ class ext_update
 	 *
 	 * TYPO3 9.5 and MySql 5.6 or MariaDB 10.1 might make problems.
 	 *
-	 * @return bool
+	 * @return null|string
+	 *   A possible return message, stating what went wrong, if anything at all.
 	 */
 	protected function checkEnvironment()
 	{
 		if( version_compare( TYPO3_version, '9.0', '<' ) )
 		{
 			// Wrong TYPO3 version.
-			return true;
+			return;
 		}
 
 		/** @var ObjectManager $objectManager */
@@ -119,7 +113,7 @@ class ext_update
 				&& version_compare( $version, '10.2', '>=' ) )
 				|| version_compare( $version, '5.7', '>=' )
 			) {
-				return true;
+				return;
 			}
 		}
 
@@ -131,7 +125,7 @@ class ext_update
 			isset( $params['tableoptions']['collate'] ) &&
 			$params['tableoptions']['collate'] === 'utf8_bin'
 		) {
-			return true;
+			return;
 		}
 
 		// Retrieve the name of the connection (which is not part of the
@@ -152,11 +146,10 @@ class ext_update
 			)
 		];
 
-		$this->message = $objectManager->get( FlashMessageRendererResolver::class )
+		return $objectManager->get( FlashMessageRendererResolver::class )
 			->resolve()
 			->render( $flashMessages ) .
 			LocalizationUtility::translate( 'LLL:EXT:aimeos/Resources/Private/Language/admin.xlf:t3_9x_config_error_remedy' );
 
-		return false;
 	}
 }

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -7,6 +7,12 @@
  * @package TYPO3_Aimeos
  */
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Messaging\FlashMessageRendererResolver;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 $localautoloader = __DIR__ . '/Resources/Libraries/autoload.php';
 
@@ -22,6 +28,13 @@ if( file_exists( $localautoloader ) === true ) {
  */
 class ext_update
 {
+	/**
+	 * Array with possible flash messages.
+	 *
+	 * @var string
+	 */
+	protected $message = '';
+
 	/**
 	 * Returns the status if an update is necessary.
 	 *
@@ -43,6 +56,10 @@ class ext_update
 		ob_start();
 		$exectimeStart = microtime( true );
 
+		if ( $this->checkEnvironment() === false ) {
+			return $this->message;
+		}
+
 		try
 		{
 			\Aimeos\Aimeos\Setup::execute();
@@ -60,5 +77,74 @@ class ext_update
 
 		return '<pre>' . $output . '</pre>' . PHP_EOL .
 			sprintf( "Setup process lasted %1\$f sec</br>\n", (microtime( true ) - $exectimeStart) );
+	}
+
+	/**
+	 * Check the environment.
+	 *
+	 * TYPO3 9.5 and MySql 5.6 and below may make problems. This was introduced
+	 * with #80398.
+	 *
+	 * @return bool
+	 */
+	protected function checkEnvironment(): bool
+	{
+		if (version_compare(TYPO3_version, '9.5', '<')) {
+			// Wrong TYPO3 version.
+			return true;
+		}
+
+		/** @var ObjectManager $objectManager */
+		$objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+
+		/** @var ConnectionPool $connectionPool */
+		$connectionPool = $objectManager->get(ConnectionPool::class);
+		// A join with tables from different databases will throw an exception.
+		// Hence, it is extreme likely that aimeos will be installed on the same
+		// database.
+		$connection = $connectionPool
+			->getQueryBuilderForTable('fe_user')
+			->getConnection();
+
+		// Test the server type
+		// @todo test MariaDB
+		//	   According to the releases, the next version here would be 10.0
+		if ( strpos( $connection->getServerVersion(), 'MySQL' ) === 0 &&
+			version_compare( $connection->getWrappedConnection()->getServerVersion(), '5.7', '>=' )
+		) {
+			return true;
+		}
+
+		// Test the parameters
+		$params = $connection->getParams();
+		if ($params['tableoptions']['charset'] === 'utf8' ||
+			$params['tableoptions']['collate'] === 'utf8_bin'
+		) {
+			return true;
+		}
+
+		// Retrieve the name of the connection (which is not part of the
+		// connection class)
+		foreach ( $connectionPool->getConnectionNames() as $name ) {
+			if ($connectionPool->getConnectionByName($name) === $connection) {
+				break;
+			}
+		}
+
+		// We have a winner!
+		$flashMessages =[
+			$objectManager->get(
+				FlashMessage::class,
+				LocalizationUtility::translate( 'LLL:EXT:aimeos/Resources/Private/Language/admin.xlf:t3_9x_config_error_text', 'aimeos', [$name] ),
+				LocalizationUtility::translate( 'LLL:EXT:aimeos/Resources/Private/Language/admin.xlf:t3_9x_config_error_header' ),
+				FlashMessage::ERROR
+			)
+		];
+
+		$this->message = $objectManager->get( FlashMessageRendererResolver::class )
+			->resolve()
+			->render( $flashMessages );
+
+		return false;
 	}
 }

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -8,7 +8,6 @@
  */
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Messaging\FlashMessageRendererResolver;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
@@ -97,8 +96,8 @@ class ext_update
 		/** @var ObjectManager $objectManager */
 		$objectManager = GeneralUtility::makeInstance( ObjectManager::class );
 
-		/** @var ConnectionPool $connectionPool */
-		$connectionPool = $objectManager->get( ConnectionPool::class );
+		/** @var \TYPO3\CMS\Core\Database\ConnectionPool $connectionPool */
+		$connectionPool = $objectManager->get( TYPO3\CMS\Core\Database\ConnectionPool::class );
 		// A join with tables from different databases will throw an exception.
 		// Hence, it is extreme likely that aimeos will be installed on the same
 		// database where the fe_user is located.


### PR DESCRIPTION
Hi everyone.

See #92.
We check the TYPO3 version, the connection settings and the MySql version.
The setup will refuse to run with the wrong combination, existing with a flash message and a link to the documentation.

The only thing missing is the MariaDB test with 8.0 and above. We can currently not provide this.

Please review and test.   😃 

Tobi