### PR TITLE
Product list by code

### DIFF
--- a/Classes/Controller/CatalogController.php
+++ b/Classes/Controller/CatalogController.php
@@ -72,6 +72,30 @@ class CatalogController extends AbstractController
 
 
 	/**
+	 * Renders the catalog product section.
+	 */
+	public function productAction()
+	{
+		$client = \Aimeos\Client\Html::create( $this->getContext(), 'catalog/product' );
+
+		if (
+			isset($this->settings['client']['html']['catalog']['product']['product-codes'])
+			&& is_string($this->settings['client']['html']['catalog']['product']['product-codes'])
+		) {
+			$productCodes = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(
+				',',
+				$this->settings['client']['html']['catalog']['product']['product-codes'],
+				true
+			);
+			$this->settings['client']['html']['catalog']['product']['product-codes'] = $productCodes;
+		} else {
+			$this->settings['client']['html']['catalog']['product']['product-codes'] = [];
+		}
+		return $this->getClientOutput( $client );
+	}
+
+
+	/**
 	 * Renders the catalog search section.
 	 */
 	public function searchAction()

--- a/Classes/Flexform/Product.php
+++ b/Classes/Flexform/Product.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @license GPLv3, http://www.gnu.org/copyleft/gpl.html
+ * @copyright Metaways Infosystems GmbH, 2013
+ * @copyright Aimeos (aimeos.org), 2014-2016
+ * @package TYPO3
+ */
+
+
+namespace Aimeos\Aimeos\Flexform;
+
+use Aimeos\Aimeos\Base;
+
+
+/**
+ * Aimeos product flexform helper.
+ *
+ * @package TYPO3
+ */
+class Product
+{
+	/**
+	 * Returns the list of products with their code.
+	 *
+	 * @param array $config Associative array of existing configurations
+	 * @param \TYPO3\CMS\Backend\Form\FormEngine|\TYPO3\CMS\Backend\Form\DataPreprocessor $tceForms TCE forms object
+	 * @param string $sitecode Unique code of the site to retrieve the categories for
+	 * @return array Associative array with existing and new entries
+	 */
+	public function getProducts( array $config, $tceForms = null, $sitecode = 'default' )
+	{
+		try {
+			if( isset( $config['flexParentDatabaseRow']['pid'] ) ) { // TYPO3 7+
+				$pid = $config['flexParentDatabaseRow']['pid'];
+			} elseif( isset( $config['row']['pid'] ) ) { // TYPO3 6.2
+				$pid = $config['row']['pid'];
+			} else {
+				throw new \Exception( 'No PID found in "flexParentDatabaseRow" or "row" array key: ' . print_r( $config, true ) );
+			}
+
+			$pageTSConfig = \TYPO3\CMS\Backend\Utility\BackendUtility::getModTSconfig( $pid, 'tx_aimeos' );
+
+			if( isset( $pageTSConfig['properties']['mshop.']['locale.']['site'] ) ) {
+				$sitecode = $pageTSConfig['properties']['mshop.']['locale.']['site'];
+			}
+
+			$context = Base::getContext( Base::getConfig() );
+			$context->setEditor( 'flexform' );
+
+			$localeManager = \Aimeos\MShop::create( $context, 'locale' );
+			$context->setLocale( $localeManager->bootstrap( $sitecode, '', '', false ) );
+
+			$manager = \Aimeos\MShop::create( $context, 'product' );
+			$search = $manager->createSearch( true );
+			$search->setSlice( 0, 10000 );
+			$search->setSortations( [$search->sort( '+', 'product.label' )] );
+
+			$products = $manager->searchItems( $search );
+
+			$config['items'] = array_map( function( $product ) {
+				return [$product->getName(), $product->getCode()];
+			}, $products );
+		} catch( \Exception $e ) {
+			error_log( $e->getMessage() . PHP_EOL . $e->getTraceAsString() );
+		}
+
+		return $config;
+	}
+}

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -35,6 +35,10 @@ $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['aimeos_catal
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue( 'aimeos_catalog-list', 'FILE:EXT:aimeos/Configuration/FlexForms/CatalogList.xml' );
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin( 'Aimeos.aimeos', 'catalog-list', 'Aimeos Shop - Catalog list' );
 
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['aimeos_catalog-product'] = 'pi_flexform';
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue( 'aimeos_catalog-product', 'FILE:EXT:aimeos/Configuration/FlexForms/CatalogProduct.xml' );
+\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin( 'Aimeos.aimeos', 'catalog-product', 'Aimeos Shop - Catalog product' );
+
 $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['aimeos_catalog-search'] = 'pi_flexform';
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue( 'aimeos_catalog-search', 'FILE:EXT:aimeos/Configuration/FlexForms/CatalogSearch.xml' );
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin( 'Aimeos.aimeos', 'catalog-search', 'Aimeos Shop - Catalog search' );

--- a/Resources/Private/Language/de.plugins.xlf
+++ b/Resources/Private/Language/de.plugins.xlf
@@ -102,6 +102,10 @@
 				<source>Page with stock level data</source>
 				<target>Seite mit Lagerbestandsdaten</target>
 			</trans-unit>
+			<trans-unit id="catalog-product.product-codes" xml:space="preserve">
+				<source>Products</source>
+				<target>Produkte</target>
+			</trans-unit>
 			<trans-unit id="basket-standard.target" xml:space="preserve">
 				<source>Basket page</source>
 				<target>Seite des Warenkorbs</target>

--- a/Resources/Private/Language/plugins.xlf
+++ b/Resources/Private/Language/plugins.xlf
@@ -78,6 +78,9 @@
 			<trans-unit id="catalog-stock.target" xml:space="preserve">
 				<source>Page with stock level data</source>
 			</trans-unit>
+			<trans-unit id="catalog-product.product-codes" xml:space="preserve">
+				<source>Products</source>
+			</trans-unit>
 			<trans-unit id="basket-standard.target" xml:space="preserve">
 				<source>Basket page</source>
 			</trans-unit>

--- a/Tests/Unit/Controller/CatalogControllerTest.php
+++ b/Tests/Unit/Controller/CatalogControllerTest.php
@@ -121,6 +121,25 @@ class CatalogControllerTest
 	/**
 	 * @test
 	 */
+	public function productAction()
+	{
+		$name = '\\Aimeos\\Client\\Html\\Catalog\\Product\\Standard';
+		$client = $this->getMock( $name, array( 'getBody', 'getHeader', 'process' ), array(), '', false );
+
+		$client->expects( $this->once() )->method( 'getBody' )->will( $this->returnValue( 'body' ) );
+		$client->expects( $this->once() )->method( 'getHeader' )->will( $this->returnValue( 'header' ) );
+
+		\Aimeos\Client\Html\Catalog\Product\Factory::injectClient( $name, $client );
+		$output = $this->object->productAction();
+		\Aimeos\Client\Html\Catalog\Product\Factory::injectClient( $name, null );
+
+		$this->assertEquals( 'body', $output );
+	}
+
+
+	/**
+	 * @test
+	 */
 	public function suggestAction()
 	{
 		$name = '\\Aimeos\\Client\\Html\\Catalog\\Suggest\\Standard';

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -67,6 +67,13 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['aimeos']['extDirs']['0_aimeos'] = 'EXT:a
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
 	'Aimeos.aimeos',
+	'catalog-product',
+	array( 'Catalog' => 'product' ),
+	array( 'Catalog' => 'product' )
+);
+
+\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+	'Aimeos.aimeos',
 	'catalog-search',
 	array( 'Catalog' => 'search' ),
 	array( 'Catalog' => 'search' )


### PR DESCRIPTION
See https://github.com/aimeos/aimeos-typo3/issues/83, https://github.com/aimeos/ai-client-html/pull/73.

This adds a Typo3 plugin for the new client Catalog/Product and a Flexform helper to select products.
I limited the product list to 10000, this should prevent overload, but prevents some products from being selectable, if the shop has more then 10000 products. I'm open for any suggestions how to resolve this.