### PR TITLE
Replace Cache\Frontend\StringFrontend

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -280,7 +280,7 @@ if( !is_array( $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfiguration
 }
 
 if( !isset( $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['aimeos']['frontend'] ) ) {
-	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['aimeos']['frontend'] = 'TYPO3\\CMS\\Core\\Cache\\Frontend\\StringFrontend';
+	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['aimeos']['frontend'] = 'TYPO3\\CMS\\Core\\Cache\\Frontend\\VariableFrontend';
 }
 
 if( !isset( $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['aimeos']['options'] ) ) {


### PR DESCRIPTION
The StringFrontend has been removed in TYPO3 v10.
Deprecation: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.2/Deprecation-81434-StringCacheFrontendDeprecated.html