### PR TITLE
Proposal: configure typoscript config Flexform field with t3editor

### DIFF
--- a/Configuration/FlexForms/AccountDownload.xml
+++ b/Configuration/FlexForms/AccountDownload.xml
@@ -24,7 +24,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountDownload.xml
+++ b/Configuration/FlexForms/AccountDownload.xml
@@ -24,13 +24,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountFavorite.xml
+++ b/Configuration/FlexForms/AccountFavorite.xml
@@ -38,13 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountFavorite.xml
+++ b/Configuration/FlexForms/AccountFavorite.xml
@@ -38,7 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountHistory.xml
+++ b/Configuration/FlexForms/AccountHistory.xml
@@ -52,7 +52,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountHistory.xml
+++ b/Configuration/FlexForms/AccountHistory.xml
@@ -52,13 +52,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountProfile.xml
+++ b/Configuration/FlexForms/AccountProfile.xml
@@ -24,7 +24,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountProfile.xml
+++ b/Configuration/FlexForms/AccountProfile.xml
@@ -24,13 +24,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountSubscription.xml
+++ b/Configuration/FlexForms/AccountSubscription.xml
@@ -38,13 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountSubscription.xml
+++ b/Configuration/FlexForms/AccountSubscription.xml
@@ -38,7 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountWatch.xml
+++ b/Configuration/FlexForms/AccountWatch.xml
@@ -38,13 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/AccountWatch.xml
+++ b/Configuration/FlexForms/AccountWatch.xml
@@ -38,7 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/BasketBulk.xml
+++ b/Configuration/FlexForms/BasketBulk.xml
@@ -38,13 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/BasketBulk.xml
+++ b/Configuration/FlexForms/BasketBulk.xml
@@ -38,7 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/BasketRelated.xml
+++ b/Configuration/FlexForms/BasketRelated.xml
@@ -38,13 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/BasketRelated.xml
+++ b/Configuration/FlexForms/BasketRelated.xml
@@ -38,7 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/BasketSmall.xml
+++ b/Configuration/FlexForms/BasketSmall.xml
@@ -38,13 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/BasketSmall.xml
+++ b/Configuration/FlexForms/BasketSmall.xml
@@ -38,7 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/BasketStandard.xml
+++ b/Configuration/FlexForms/BasketStandard.xml
@@ -80,13 +80,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/BasketStandard.xml
+++ b/Configuration/FlexForms/BasketStandard.xml
@@ -80,7 +80,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogAttribute.xml
+++ b/Configuration/FlexForms/CatalogAttribute.xml
@@ -64,7 +64,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogAttribute.xml
+++ b/Configuration/FlexForms/CatalogAttribute.xml
@@ -64,13 +64,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogCount.xml
+++ b/Configuration/FlexForms/CatalogCount.xml
@@ -10,13 +10,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogCount.xml
+++ b/Configuration/FlexForms/CatalogCount.xml
@@ -10,7 +10,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogDetail.xml
+++ b/Configuration/FlexForms/CatalogDetail.xml
@@ -126,7 +126,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogDetail.xml
+++ b/Configuration/FlexForms/CatalogDetail.xml
@@ -126,13 +126,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogFilter.xml
+++ b/Configuration/FlexForms/CatalogFilter.xml
@@ -130,13 +130,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogFilter.xml
+++ b/Configuration/FlexForms/CatalogFilter.xml
@@ -130,7 +130,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogList.xml
+++ b/Configuration/FlexForms/CatalogList.xml
@@ -177,7 +177,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogList.xml
+++ b/Configuration/FlexForms/CatalogList.xml
@@ -177,13 +177,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogSearch.xml
+++ b/Configuration/FlexForms/CatalogSearch.xml
@@ -52,7 +52,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogSearch.xml
+++ b/Configuration/FlexForms/CatalogSearch.xml
@@ -52,13 +52,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogSession.xml
+++ b/Configuration/FlexForms/CatalogSession.xml
@@ -38,13 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogSession.xml
+++ b/Configuration/FlexForms/CatalogSession.xml
@@ -38,7 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogStage.xml
+++ b/Configuration/FlexForms/CatalogStage.xml
@@ -70,13 +70,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogStage.xml
+++ b/Configuration/FlexForms/CatalogStage.xml
@@ -70,7 +70,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogStock.xml
+++ b/Configuration/FlexForms/CatalogStock.xml
@@ -10,13 +10,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogStock.xml
+++ b/Configuration/FlexForms/CatalogStock.xml
@@ -10,7 +10,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogSuggest.xml
+++ b/Configuration/FlexForms/CatalogSuggest.xml
@@ -24,7 +24,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogSuggest.xml
+++ b/Configuration/FlexForms/CatalogSuggest.xml
@@ -24,13 +24,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogSupplier.xml
+++ b/Configuration/FlexForms/CatalogSupplier.xml
@@ -52,7 +52,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogSupplier.xml
+++ b/Configuration/FlexForms/CatalogSupplier.xml
@@ -52,13 +52,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogTree.xml
+++ b/Configuration/FlexForms/CatalogTree.xml
@@ -90,7 +90,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CatalogTree.xml
+++ b/Configuration/FlexForms/CatalogTree.xml
@@ -90,13 +90,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CheckoutConfirm.xml
+++ b/Configuration/FlexForms/CheckoutConfirm.xml
@@ -66,7 +66,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CheckoutConfirm.xml
+++ b/Configuration/FlexForms/CheckoutConfirm.xml
@@ -66,13 +66,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CheckoutStandard.xml
+++ b/Configuration/FlexForms/CheckoutStandard.xml
@@ -136,7 +136,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CheckoutStandard.xml
+++ b/Configuration/FlexForms/CheckoutStandard.xml
@@ -136,13 +136,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CheckoutUpdate.xml
+++ b/Configuration/FlexForms/CheckoutUpdate.xml
@@ -38,13 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/CheckoutUpdate.xml
+++ b/Configuration/FlexForms/CheckoutUpdate.xml
@@ -38,7 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/Jsonapi.xml
+++ b/Configuration/FlexForms/Jsonapi.xml
@@ -38,13 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/Jsonapi.xml
+++ b/Configuration/FlexForms/Jsonapi.xml
@@ -38,7 +38,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/LocaleSelect.xml
+++ b/Configuration/FlexForms/LocaleSelect.xml
@@ -24,7 +24,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-						<rows>10</rows>
+            <renderType>t3editor</renderType>
+            <format>typoscript</format>
+						<rows>15</rows>
+            <cols>50</cols>
+            <wrap>off</wrap>
+            <fixedFont>true</fixedFont>
+            <enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>

--- a/Configuration/FlexForms/LocaleSelect.xml
+++ b/Configuration/FlexForms/LocaleSelect.xml
@@ -24,13 +24,13 @@
 					<label>LLL:EXT:aimeos/Resources/Private/Language/plugins.xlf:default.typo3.tsconfig</label>
 					<config>
 						<type>text</type>
-            <renderType>t3editor</renderType>
-            <format>typoscript</format>
+						<renderType>t3editor</renderType>
+						<format>typoscript</format>
 						<rows>15</rows>
-            <cols>50</cols>
-            <wrap>off</wrap>
-            <fixedFont>true</fixedFont>
-            <enableTabulator>true</enableTabulator>
+						<cols>50</cols>
+						<wrap>off</wrap>
+						<fixedFont>true</fixedFont>
+						<enableTabulator>true</enableTabulator>
 					</config>
 				</TCEforms>
 			</settings.typo3.tsconfig>


### PR DESCRIPTION
Copying and pasting paths from the docu to the Typoscript configuration field usually involves fixing the folders paths by changing all slashes to dots. This would be easier to do, when 

1. the field is larger;

2. the field has some text editor capabilities, especially multiple cursors.

