### PR TITLE
Remove typo3/cms-composer-installers again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
 		"typo3/cms-backend": "~9.5||~10.4",
 		"typo3/cms-extbase": "~9.5||~10.4",
 		"typo3/cms-scheduler": "~9.5||~10.4",
-		"typo3/cms-composer-installers": "~3.0",
 		"aimeos/aimeos-core": "dev-master",
 		"aimeos/ai-gettext": "dev-master",
 		"aimeos/ai-typo3": "dev-master",


### PR DESCRIPTION
This dependency is currently not needed as there is no usage of this
package directly. It's only used to install this extension correctly but
therefor the dependency to typo3/cms-core is important only.