### PR TITLE
[BUGFIX] Fix exception because of undefined variable

### DIFF
--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -8,6 +8,7 @@ if( !defined( 'TYPO3_MODE' ) ) {
 $beUsersSiteFcn = function() {
 
 	$list = [['', '']];
+	$db = $conn = null;
 	$dbname = 'db-locale';
 
 	try


### PR DESCRIPTION
fix issue with PHP 8

```
PHP Warning: Undefined variable $db in /var/www/html/app/site/public/typo3conf/ext/aimeos/Configuration/TCA/Overrides/be_users.php line 52
```