### PR TITLE
Support databases other than MySQL for mshop/Index/Manager

### DIFF
--- a/Resources/Private/Config/mshop.php
+++ b/Resources/Private/Config/mshop.php
@@ -1,5 +1,20 @@
 <?php
 
+$defaultConnection = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];
+$driver = $defaultConnection['driver'];
+
+/* setup class name for aimeos-core/src/MShop/Index/Manager/ */
+switch($driver) {
+	case 'mysql':
+	case 'mysqli':
+	case 'pdo_mysql': $mshopIndexManagerAdapter = 'MySQL'; break;
+	case 'pgsql':
+	case 'pdo_pgsql': $mshopIndexManagerAdapter = 'PgSQL'; break;
+	case 'sqlsrv':
+	case 'pdo_sqlsrv': $mshopIndexManagerAdapter = 'SQLSrv'; break;
+	default: $mshopIndexManagerAdapter = 'Standard';
+}
+
 return [
 	'customer' => [
 		'manager' => [
@@ -8,21 +23,21 @@ return [
 	],
 	'index' => [
 		'manager' => [
-			'name' => 'MySQL',
+			'name' => $mshopIndexManagerAdapter,
 			'attribute' => [
-				'name' => 'MySQL',
+				'name' => $mshopIndexManagerAdapter,
 			],
 			'catalog' => [
-				'name' => 'MySQL',
+				'name' => $mshopIndexManagerAdapter,
 			],
 			'price' => [
-				'name' => 'MySQL',
+				'name' => $mshopIndexManagerAdapter,
 			],
 			'supplier' => [
-				'name' => 'MySQL',
+				'name' => $mshopIndexManagerAdapter,
 			],
 			'text' => [
-				'name' => 'MySQL',
+				'name' => $mshopIndexManagerAdapter,
 			],
 		],
 	],

--- a/Resources/Private/Config/mshop.php
+++ b/Resources/Private/Config/mshop.php
@@ -1,18 +1,17 @@
 <?php
 
-$defaultConnection = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];
-$driver = $defaultConnection['driver'];
+$defaultConnection = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'] ?? [];
+$driver = $defaultConnection['driver'] ?? null;
 
-/* setup class name for aimeos-core/src/MShop/Index/Manager/ */
 switch($driver) {
 	case 'mysql':
 	case 'mysqli':
-	case 'pdo_mysql': $mshopIndexManagerAdapter = 'MySQL'; break;
+	case 'pdo_mysql': $manager = 'MySQL'; break;
 	case 'pgsql':
-	case 'pdo_pgsql': $mshopIndexManagerAdapter = 'PgSQL'; break;
+	case 'pdo_pgsql': $manager = 'PgSQL'; break;
 	case 'sqlsrv':
-	case 'pdo_sqlsrv': $mshopIndexManagerAdapter = 'SQLSrv'; break;
-	default: $mshopIndexManagerAdapter = 'Standard';
+	case 'pdo_sqlsrv': $manager = 'SQLSrv'; break;
+	default: $manager = 'Standard';
 }
 
 return [
@@ -23,21 +22,21 @@ return [
 	],
 	'index' => [
 		'manager' => [
-			'name' => $mshopIndexManagerAdapter,
+			'name' => $manager,
 			'attribute' => [
-				'name' => $mshopIndexManagerAdapter,
+				'name' => $manager,
 			],
 			'catalog' => [
-				'name' => $mshopIndexManagerAdapter,
+				'name' => $manager,
 			],
 			'price' => [
-				'name' => $mshopIndexManagerAdapter,
+				'name' => $manager,
 			],
 			'supplier' => [
-				'name' => $mshopIndexManagerAdapter,
+				'name' => $manager,
 			],
 			'text' => [
-				'name' => $mshopIndexManagerAdapter,
+				'name' => $manager,
 			],
 		],
 	],


### PR DESCRIPTION
The commit in this pull request adds support for databases other than MySQL to https://github.com/aimeos/aimeos-typo3/blob/6cc8e0d557226aaadc7cb000382336edbc83fc65/Resources/Private/Config/mshop.php#L11

Fixes #200 
