### PR TITLE
mitigate usage of closure in $GLOBALS['TYPO3_CONF_VARS']

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -309,9 +309,7 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['logout_confirmed']
 }
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['aimeos'] ) ) {
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['aimeos'] = function(array $cacheType, $dataHandler ) {
-        \Aimeos\Aimeos\Base::clearCache($cacheType );
-    };
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['aimeos'] = \Aimeos\Aimeos\Utility\Cache::class . '->clearCachePostProc';
 }
 
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -309,7 +309,7 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['logout_confirmed']
 }
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['aimeos'] ) ) {
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['aimeos'] = \Aimeos\Aimeos\Base::class . '->clearCachePostProc';
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['aimeos'] = \Aimeos\Aimeos\Base::class . '->clearCache';
 }
 
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -309,7 +309,7 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['logout_confirmed']
 }
 
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['aimeos'] ) ) {
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['aimeos'] = \Aimeos\Aimeos\Utility\Cache::class . '->clearCachePostProc';
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['aimeos'] = \Aimeos\Aimeos\Base::class . '->clearCachePostProc';
 }
 
 


### PR DESCRIPTION
resolves a bug in Typo3 v12 Configuration Module, making it not accessible