### PR TITLE
Add request to StandaloneView

### DIFF
--- a/Classes/Base/View.php
+++ b/Classes/Base/View.php
@@ -39,6 +39,7 @@ class View
         $view = GeneralUtility::makeInstance(\TYPO3\CMS\Fluid\View\StandaloneView::class);
         $view->setPartialRootPaths( $config['view']['partialRootPaths'] ?? [] );
         $view->setLayoutRootPaths( $config['view']['layoutRootPaths'] ?? [] );
+        $view->setRequest($request);
 
         $engines = ['.html' => new \Aimeos\Base\View\Engine\Typo3($view)];
 


### PR DESCRIPTION
The ActionViewHelper excepts a request to be defined in the rendering context otherwise it will throw an error.
There might be other cases of view helpers using the request from the view.