### PR TITLE
Do not break extension configuration on update wizard execution

### DIFF
--- a/Classes/Setup.php
+++ b/Classes/Setup.php
@@ -147,7 +147,7 @@ class Setup implements UpgradeWizardInterface, RepeatableInterface, ChattyInterf
             ->context($ctx->setEditor('aimeos:setup'))
             ->up($site, $template);
 
-        $extconf->set('aimeos', ['useDemoData' => '']);
+        $extconf->set('aimeos', array_merge($extconf->get('aimeos'), ['useDemoData' => '']));
     }
 
 


### PR DESCRIPTION
Only replace the useDemoData configuration option with an empty value. Keep the remaining existing configuration, if any exists already.

The `->set()` API will replace the whole configuration and previously removed all other options, falling back to the extension defaults.

Relates: #213