### PR TITLE
Check if there is a request before evaluating the session

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -45,7 +45,7 @@ plugin.tx_aimeos {
 }
 
 # Exclude the shopping basket from the page cache, once it has been initialized
-[session("aimeos/basket/list") !== null]
+[request && session("aimeos/basket/list") !== null]
     tt_content.list.20.aimeos_basket-small = USER_INT
 [end]
 


### PR DESCRIPTION
When using the session condition in TypoScript without checking if there is a request TYPO3 might throw an error because the session condition requires a request to be present. 

This especially happens when other extensions make use of the TypoScript record in the backend.