### PR TITLE
Fixed broken TypoScript for aimeos_basket-small

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -44,6 +44,8 @@ plugin.tx_aimeos {
     }
 }
 
+tt_content.list.20.aimeos_basket-small = USER
+tt_content.list.20.aimeos_basket-small.userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
 # Exclude the shopping basket from the page cache, once it has been initialized
 [request && session("aimeos/basket/list") !== null]
     tt_content.list.20.aimeos_basket-small = USER_INT


### PR DESCRIPTION
`ext_localconf.php` registers the plugin, which will result in `= EXTBASEPLUGIN` since TYPO3 v12.3.0.

The TypoScript will convert it to `USER_INT` but there is no `userFunc`, that way it will never work once session exists.

We therefore migrate it to `USER` upfront to keep old matching configuration.

Resolves: #251